### PR TITLE
[BUGFIX] Respect data type (table name) in FacetSuggestionService::getSuggestions()

### DIFF
--- a/Classes/Facet/FacetSuggestionService.php
+++ b/Classes/Facet/FacetSuggestionService.php
@@ -78,10 +78,10 @@ class FacetSuggestionService {
 
 				// Fetch the adequate repository
 				/** @var \TYPO3\CMS\Vidi\Domain\Repository\ContentRepository $contentRepository */
-				$contentRepository = ContentRepositoryFactory::getInstance();
+				$contentRepository = ContentRepositoryFactory::getInstance($dataType);
 
 				// Initialize some objects related to the query
-				$matcher = MatcherObjectFactory::getInstance()->getMatcher();
+				$matcher = MatcherObjectFactory::getInstance()->getMatcher(array(), $dataType);
 
 				// Count the number of objects.
 				$numberOfValues = $contentRepository->countDistinctValues($fieldName, $matcher);


### PR DESCRIPTION
Until now an exception was thrown if a facet is configured for a field of a
datatype (table name) other than  ModuleLoader::getDataType:

#1385554481: Does the field really exist? No TCA entry found for field "title"

This only happens in FacetSuggestionService::getSuggestions() if [1] the field
is not configured as text area and [2] the number of suggestions is lower or
equal the configured limit.

Example: adding a facet for sys_file_metadata.title for EXT:media