### PR TITLE
safeguard if EXT:scheduler is not loaded

### DIFF
--- a/Configuration/TCA/Overrides/tx_scheduler_task_group.php
+++ b/Configuration/TCA/Overrides/tx_scheduler_task_group.php
@@ -1,12 +1,14 @@
 <?php
 if (!defined('TYPO3_MODE')) die ('Access denied.');
 
-$tca = array(
-	'vidi' => array(
-		'mappings' => array(
-			'groupName' => 'groupName'
+if (\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('scheduler')) {
+	$tca = array(
+		'vidi' => array(
+			'mappings' => array(
+				'groupName' => 'groupName'
+			)
 		)
-	)
-);
-
-\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TCA']['tx_scheduler_task_group'], $tca);
+	);
+	
+	\TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TCA']['tx_scheduler_task_group'], $tca);
+}


### PR DESCRIPTION
if EXT:scheduler is not loaded, then the call mergeRecursiveWithOverrule will render Frontend AND Backend broken