### PR TITLE
[BUGFIX] Double-type field is also numeric

### DIFF
--- a/Classes/Tca/FieldService.php
+++ b/Classes/Tca/FieldService.php
@@ -311,7 +311,7 @@ class FieldService extends AbstractTca {
 					$fieldType = FieldType::DATE;
 				} elseif (in_array('email', $parts)) {
 					$fieldType = FieldType::EMAIL;
-				} elseif (in_array('int', $parts)) {
+				} elseif (in_array('int', $parts) || in_array('double2', $parts)) {
 					$fieldType = FieldType::NUMBER;
 				}
 			}


### PR DESCRIPTION
Input-type fields with "double2" in their "eval" property should also be recognized as being numeric.