### PR TITLE
[BUGFIX] Fixed "Export selected items" feature

### DIFF
--- a/Classes/Controller/Backend/ContentController.php
+++ b/Classes/Controller/Backend/ContentController.php
@@ -99,8 +99,12 @@ class ContentController extends ActionController
         $order = OrderObjectFactory::getInstance()->getOrder();
         $pager = PagerObjectFactory::getInstance()->getPager();
 
+        // If we are given a list of uids to export, do not use a limit because we want them all.
+        $inCriteria = $matcher->getInCriteria();
+        $limit = empty($inCriteria) ? $pager->getLimit() : NULL;
+
         // Fetch objects via the Content Service.
-        $contentService = $this->getContentService()->findBy($matcher, $order, $pager->getLimit(), $pager->getOffset());
+        $contentService = $this->getContentService()->findBy($matcher, $order, $limit, $pager->getOffset());
         $pager->setCount($contentService->getNumberOfObjects());
 
         // Assign values.


### PR DESCRIPTION
Fixed "Export selected items" feature, which kept a limit of 10 items even if more are selected.
More precisely this concerns the "For selected rows..." > "Export ...". : it was impossible to export more than 10 items.