### PR TITLE
Add "replace" section to Composer manifest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,10 @@
 			"Fab\\Vidi\\": "Classes/"
 		}
 	},
+	"replace": {
+		"vidi": "self.version",
+		"typo3-ter/vidi": "self.version"
+	},
 	"extra": {
 		"autoload-case-sensitivity": false,
 		"class-alias-maps": [


### PR DESCRIPTION
This makes sure that one can e.g. fetch "fab/vidi" via Github and have it
satisfy dependencies of "typo3-ter/media".