### PR TITLE
Update TCA for tx_vidi_selection.visibility

### DIFF
--- a/Configuration/TCA/tx_vidi_selection.php
+++ b/Configuration/TCA/tx_vidi_selection.php
@@ -18,7 +18,7 @@ return [
         ],
     ],
     'types' => [
-        '1' => ['showitem' => 'hidden;;1, type, name, data_type, query'],
+        '1' => ['showitem' => 'hidden,--palette--;;1, type, name, data_type, query'],
     ],
     'palettes' => [
         '1' => ['showitem' => ''],
@@ -37,6 +37,7 @@ return [
             'label' => 'LLL:EXT:vidi/Resources/Private/Language/tx_vidi_selection.xlf:visibility',
             'config' => [
                 'type' => 'select',
+                'renderType' => 'selectSingle',
                 'items' => [
                     ['LLL:EXT:vidi/Resources/Private/Language/tx_vidi_selection.xlf:visibility.everyone', 0],
                     ['LLL:EXT:vidi/Resources/Private/Language/tx_vidi_selection.xlf:visibility.private', 1],


### PR DESCRIPTION
The TCA Migration wizard in 7.6 suggested the following changes:

* Add required TCA renderType config to tx_vidi_selection.visibility
* Move palette setting for the field hidden to an own palette