### PR TITLE
[TASK] Remove unnecessary include of setup.ts in ext_typoscript_setup…

### DIFF
--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -1,5 +1,3 @@
-<INCLUDE_TYPOSCRIPT: source="FILE:EXT:vidi/Configuration/TypoScript/setup.txt">
-
 config.tx_extbase {
 	persistence{
 		classes {


### PR DESCRIPTION
The include of the TypoScript setup inside of ext_typoscript_setup.txt makes
it impossible to be overwritten by files from other extensions.
There's also no need to include the setup file here.

Resolves: #184