### PR TITLE
Add backend module configuration for Vidi extension

### DIFF
--- a/Classes/Module/ModuleLoader.php
+++ b/Classes/Module/ModuleLoader.php
@@ -308,22 +308,6 @@ class ModuleLoader
             } else {
                 $moduleConfiguration['inheritNavigationComponentFromMainModule'] = true;
             }
-
-            ExtensionUtility::registerModule(
-                'Vidi',
-                $this->computeMainModule(),
-                $this->dataType . '_' . $this->moduleKey,
-                $this->position,
-                [
-                    ContentController::class => 'index, list, delete, update, edit, copy, move, localize, sort, copyClipboard, moveClipboard',
-                    ToolController::class => 'welcome, work',
-                    FacetController::class => 'autoSuggest, autoSuggests',
-                    SelectionController::class => 'edit, update, create, delete, list, show',
-                    UserPreferencesController::class => 'save',
-                    ClipboardController::class => 'save, flush, show',
-                ],
-                $moduleConfiguration
-            );
         }
         return $this;
     }

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Fab\Vidi\Controller\ContentController;
+
+/**
+ * Backend module configuration for Vidi extension.
+ * This file registers backend modules for the configured data types.
+ * 
+ * Configured data types: fe_users, fe_groups, tt_address
+ * Main module: content
+ */
+return [
+    // Module for fe_users
+    'content_vidi_fe_users_m1' => [
+        'parent' => 'content',
+        'position' => ['after' => 'web_list'],
+        'access' => 'user,group',
+        'path' => '/module/vidi/fe_users',
+        'iconIdentifier' => 'module-vidi',
+        'labels' => 'LLL:EXT:vidi/Resources/Private/Language/locallang_mod.xlf',
+        'routes' => [
+            '_default' => [
+                'target' => ContentController::class . '::indexAction',
+            ],
+        ],
+        'navigationComponentId' => 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
+        'inheritNavigationComponentFromMainModule' => true,
+    ],
+    
+    // Module for fe_groups
+    'content_vidi_fe_groups_m1' => [
+        'parent' => 'content',
+        'position' => ['after' => 'content_vidi_fe_users_m1'],
+        'access' => 'user,group',
+        'path' => '/module/vidi/fe_groups',
+        'iconIdentifier' => 'module-vidi',
+        'labels' => 'LLL:EXT:vidi/Resources/Private/Language/locallang_mod.xlf',
+        'routes' => [
+            '_default' => [
+                'target' => ContentController::class . '::indexAction',
+            ],
+        ],
+        'navigationComponentId' => 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
+        'inheritNavigationComponentFromMainModule' => true,
+    ],
+    
+    // Module for tt_address
+    'content_vidi_tt_address_m1' => [
+        'parent' => 'content',
+        'position' => ['after' => 'content_vidi_fe_groups_m1'],
+        'access' => 'user,group',
+        'path' => '/module/vidi/tt_address',
+        'iconIdentifier' => 'module-vidi',
+        'labels' => 'LLL:EXT:vidi/Resources/Private/Language/locallang_mod.xlf',
+        'routes' => [
+            '_default' => [
+                'target' => ContentController::class . '::indexAction',
+            ],
+        ],
+        'navigationComponentId' => 'TYPO3/CMS/Backend/PageTree/PageTreeElement',
+        'inheritNavigationComponentFromMainModule' => true,
+    ],
+];


### PR DESCRIPTION
This file registers backend modules for the Vidi extension, including modules for fe_users, fe_groups, and tt_address.